### PR TITLE
build clang with latest llvm

### DIFF
--- a/builders.py
+++ b/builders.py
@@ -938,19 +938,14 @@ class DeviceSysrootsBuilder(base_builders.Builder):
 
         # Copy the NDK prebuilt's sysroot, but for the platform variant, omit
         # the STL and android_support headers and libraries.
-        if arch == hosts.Arch.RISCV64:
-            src_sysroot = paths.RISCV64_ANDROID_SYSROOT
-        else:
-            src_sysroot = paths.NDK_BASE / 'toolchains' / 'llvm' / 'prebuilt' / 'linux-x86_64' / 'sysroot'
+        src_sysroot = paths.NDK_BASE / 'toolchains' / 'llvm' / 'prebuilt' / 'linux-x86_64' / 'sysroot'
 
         # Copy over usr/include.
         shutil.copytree(src_sysroot / 'usr' / 'include',
                         sysroot / 'usr' / 'include', symlinks=True)
 
         if platform:
-            if arch != hosts.Arch.RISCV64:
-                # Remove the STL headers.
-                shutil.rmtree(sysroot / 'usr' / 'include' / 'c++')
+            shutil.rmtree(sysroot / 'usr' / 'include' / 'c++')
         else:
             # Add the android_support headers from usr/local/include.
             shutil.copytree(src_sysroot / 'usr' / 'local' / 'include',
@@ -965,7 +960,7 @@ class DeviceSysrootsBuilder(base_builders.Builder):
         # the NDK libc++, except for the riscv64 sysroot which doesn't have
         # these files.
         (dest_lib / 'libcompiler_rt-extras.a').unlink()
-        if platform and arch != hosts.Arch.RISCV64:
+        if platform:
             (dest_lib / 'libc++abi.a').unlink()
             (dest_lib / 'libc++_static.a').unlink()
             (dest_lib / 'libc++_shared.so').unlink()
@@ -975,7 +970,8 @@ class DeviceSysrootsBuilder(base_builders.Builder):
                 continue
             if not re.match(r'\d+$', subdir.name):
                 continue
-            if platform and arch != hosts.Arch.RISCV64:
+            (subdir / 'libcompiler_rt-extras.a').unlink()
+            if platform:
                 (subdir / 'libc++.a').unlink()
                 (subdir / 'libc++.so').unlink()
         # Verify that there aren't any extra copies somewhere else in the

--- a/configs.py
+++ b/configs.py
@@ -531,8 +531,6 @@ class AndroidConfig(_BaseConfig):
     def api_level(self) -> int:
         if self.override_api_level:
             return self.override_api_level
-        if self.target_arch == hosts.Arch.RISCV64:
-            return 10000
         if self.static or self.platform:
             # Set API level for platform to to 29 since these runtimes can be
             # used for apexes targeting that API level.

--- a/constants.py
+++ b/constants.py
@@ -24,7 +24,7 @@ MAC_MIN_VERSION: str = '10.14'
 CLANG_PREBUILT_VERSION: str = 'clang-r468909b'
 
 # This is the ndk version used to build runtimes.
-NDK_VERSION: str = 'r25'
+NDK_VERSION: str = 'r23'
 
 # Targets for host.
 HOST_TARGETS: Set[str] = set(['X86', 'AArch64'])


### PR DESCRIPTION
use ndk 23 from RVI android SIG, because we want to build chrome and run it on aosp 12 for riscv64.

roll-back some changes of google, which are introduced from https://android-review.googlesource.com/c/toolchain/llvm_android/+/2261059

Change-Id: Ieb858eb8210a9bcb79713482b3c3374bf95b8f7d
Signed-off-by: Wang Chen <wangchen20@iscas.ac.cn>